### PR TITLE
Add chgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ diag:	${SRC}/diag_header.f90\
 	${SRC}/out_fluidtotaltrans.f90\
 	${SRC}/out_fluidsubsptrans.f90\
 	${SRC}/out_fluiddetailtrans.f90\
+	${SRC}/diag_chgres_util.f90\
+	${SRC}/diag_chgres_cnt.f90\
 	${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} -c ${SRC}/diag_header.f90
@@ -109,6 +111,8 @@ diag:	${SRC}/diag_header.f90\
 	${FC} ${FFLAGS} -c ${SRC}/out_fluidtotaltrans.f90
 #	${FC} ${FFLAGS} -c ${SRC}/out_fluidsubsptrans.f90
 	${FC} ${FFLAGS} -c ${SRC}/out_fluiddetailtrans.f90
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_util.f90 ${INC}
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_cnt.f90 ${INC}
 	${FC} ${FFLAGS} -c ${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} *.o -o ${PROG} ${LIB}

--- a/backup/Makefile_flow
+++ b/backup/Makefile_flow
@@ -70,6 +70,8 @@ diag:	${SRC}/diag_header.f90\
 	${SRC}/out_fluidtotaltrans.f90\
 	${SRC}/out_fluidsubsptrans.f90\
 	${SRC}/out_fluiddetailtrans.f90\
+	${SRC}/diag_chgres_util.f90\
+	${SRC}/diag_chgres_cnt.f90\
 	${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} -c ${SRC}/diag_header.f90
@@ -109,6 +111,8 @@ diag:	${SRC}/diag_header.f90\
 	${FC} ${FFLAGS} -c ${SRC}/out_fluidtotaltrans.f90
 #	${FC} ${FFLAGS} -c ${SRC}/out_fluidsubsptrans.f90
 	${FC} ${FFLAGS} -c ${SRC}/out_fluiddetailtrans.f90
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_util.f90 ${INC}
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_cnt.f90 ${INC}
 	${FC} ${FFLAGS} -c ${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} *.o -o ${PROG} ${LIB}

--- a/backup/Makefile_fugaku
+++ b/backup/Makefile_fugaku
@@ -77,6 +77,8 @@ diag:	${SRC}/diag_header.f90\
 	${SRC}/out_fluidtotaltrans.f90\
 	${SRC}/out_fluidsubsptrans.f90\
 	${SRC}/out_fluiddetailtrans.f90\
+	${SRC}/diag_chgres_util.f90\
+	${SRC}/diag_chgres_cnt.f90\
 	${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} -c ${SRC}/diag_header.f90
@@ -116,6 +118,8 @@ diag:	${SRC}/diag_header.f90\
 	${FC} ${FFLAGS} -c ${SRC}/out_fluidtotaltrans.f90
 #	${FC} ${FFLAGS} -c ${SRC}/out_fluidsubsptrans.f90
 	${FC} ${FFLAGS} -c ${SRC}/out_fluiddetailtrans.f90
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_util.f90 ${INC}
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_cnt.f90 ${INC}
 	${FC} ${FFLAGS} -c ${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} *.o -o ${PROG} ${LIB}

--- a/backup/Makefile_fugaku_ppmq
+++ b/backup/Makefile_fugaku_ppmq
@@ -101,6 +101,8 @@ diag:	${SRC}/diag_header.f90\
 	${SRC}/out_fluidtotaltrans.f90\
 	${SRC}/out_fluidsubsptrans.f90\
 	${SRC}/out_fluiddetailtrans.f90\
+	${SRC}/diag_chgres_util.f90\
+	${SRC}/diag_chgres_cnt.f90\
 	${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} -c ${SRC}/diag_header.f90
@@ -140,6 +142,8 @@ diag:	${SRC}/diag_header.f90\
 	${FC} ${FFLAGS} -c ${SRC}/out_fluidtotaltrans.f90
 #	${FC} ${FFLAGS} -c ${SRC}/out_fluidsubsptrans.f90
 	${FC} ${FFLAGS} -c ${SRC}/out_fluiddetailtrans.f90
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_util.f90 ${INC}
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_cnt.f90 ${INC}
 	${FC} ${FFLAGS} -c ${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} *.o -o ${PROG} ${LIB}

--- a/backup/Makefile_ito
+++ b/backup/Makefile_ito
@@ -65,6 +65,8 @@ diag:	${SRC}/diag_header.f90\
 	${SRC}/out_fluidtotaltrans.f90\
 	${SRC}/out_fluidsubsptrans.f90\
 	${SRC}/out_fluiddetailtrans.f90\
+	${SRC}/diag_chgres_util.f90\
+	${SRC}/diag_chgres_cnt.f90\
 	${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} -c ${SRC}/diag_header.f90
@@ -104,6 +106,8 @@ diag:	${SRC}/diag_header.f90\
 	${FC} ${FFLAGS} -c ${SRC}/out_fluidtotaltrans.f90
 #	${FC} ${FFLAGS} -c ${SRC}/out_fluidsubsptrans.f90
 	${FC} ${FFLAGS} -c ${SRC}/out_fluiddetailtrans.f90
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_util.f90 ${INC}
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_cnt.f90 ${INC}
 	${FC} ${FFLAGS} -c ${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} *.o -o ${PROG} ${LIB}

--- a/backup/Makefile_jfrs
+++ b/backup/Makefile_jfrs
@@ -73,6 +73,8 @@ diag:	${SRC}/diag_header.f90\
 	${SRC}/out_fluidtotaltrans.f90\
 	${SRC}/out_fluidsubsptrans.f90\
 	${SRC}/out_fluiddetailtrans.f90\
+	${SRC}/diag_chgres_util.f90\
+	${SRC}/diag_chgres_cnt.f90\
 	${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} -c ${SRC}/diag_header.f90
@@ -112,6 +114,8 @@ diag:	${SRC}/diag_header.f90\
 	${FC} ${FFLAGS} -c ${SRC}/out_fluidtotaltrans.f90
 #	${FC} ${FFLAGS} -c ${SRC}/out_fluidsubsptrans.f90
 	${FC} ${FFLAGS} -c ${SRC}/out_fluiddetailtrans.f90
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_util.f90 ${INC}
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_cnt.f90 ${INC}
 	${FC} ${FFLAGS} -c ${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} *.o -o ${PROG} ${LIB}

--- a/backup/Makefile_p-srv
+++ b/backup/Makefile_p-srv
@@ -62,6 +62,8 @@ diag:	${SRC}/diag_header.f90\
 	${SRC}/out_fluidtotaltrans.f90\
 	${SRC}/out_fluidsubsptrans.f90\
 	${SRC}/out_fluiddetailtrans.f90\
+	${SRC}/diag_chgres_util.f90\
+	${SRC}/diag_chgres_cnt.f90\
 	${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} -c ${SRC}/diag_header.f90
@@ -101,6 +103,8 @@ diag:	${SRC}/diag_header.f90\
 	${FC} ${FFLAGS} -c ${SRC}/out_fluidtotaltrans.f90
 #	${FC} ${FFLAGS} -c ${SRC}/out_fluidsubsptrans.f90
 	${FC} ${FFLAGS} -c ${SRC}/out_fluiddetailtrans.f90
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_util.f90 ${INC}
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_cnt.f90 ${INC}
 	${FC} ${FFLAGS} -c ${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} *.o -o ${PROG} ${LIB}

--- a/backup/Makefile_ps_sx
+++ b/backup/Makefile_ps_sx
@@ -61,6 +61,8 @@ diag:	${SRC}/diag_header.f90\
 	${SRC}/out_fluidtotaltrans.f90\
 	${SRC}/out_fluidsubsptrans.f90\
 	${SRC}/out_fluiddetailtrans.f90\
+	${SRC}/diag_chgres_util.f90\
+	${SRC}/diag_chgres_cnt.f90\
 	${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} -c ${SRC}/diag_header.f90
@@ -100,6 +102,8 @@ diag:	${SRC}/diag_header.f90\
 	${FC} ${FFLAGS} -c ${SRC}/out_fluidtotaltrans.f90
 #	${FC} ${FFLAGS} -c ${SRC}/out_fluidsubsptrans.f90
 	${FC} ${FFLAGS} -c ${SRC}/out_fluiddetailtrans.f90
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_util.f90 ${INC}
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_cnt.f90 ${INC}
 	${FC} ${FFLAGS} -c ${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} *.o -o ${PROG} ${LIB}

--- a/backup/Makefile_ubuntu
+++ b/backup/Makefile_ubuntu
@@ -62,6 +62,8 @@ diag:	${SRC}/diag_header.f90\
 	${SRC}/out_fluidtotaltrans.f90\
 	${SRC}/out_fluidsubsptrans.f90\
 	${SRC}/out_fluiddetailtrans.f90\
+	${SRC}/diag_chgres_util.f90\
+	${SRC}/diag_chgres_cnt.f90\
 	${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} -c ${SRC}/diag_header.f90
@@ -101,6 +103,8 @@ diag:	${SRC}/diag_header.f90\
 	${FC} ${FFLAGS} -c ${SRC}/out_fluidtotaltrans.f90
 #	${FC} ${FFLAGS} -c ${SRC}/out_fluidsubsptrans.f90
 	${FC} ${FFLAGS} -c ${SRC}/out_fluiddetailtrans.f90
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_util.f90 ${INC}
+	${FC} ${FFLAGS} -c ${SRC}/diag_chgres_cnt.f90 ${INC}
 	${FC} ${FFLAGS} -c ${SRC}/diag_main.f90
 
 	${FC} ${FFLAGS} *.o -o ${PROG} ${LIB}

--- a/backup/go.diag_ps_sx
+++ b/backup/go.diag_ps_sx
@@ -36,7 +36,7 @@
 ##############
 
 #PBS -q small                     # queue name
-#PBS --group=20223                # resource group
+#PBS --group=21234                # resource group
 #PBS -T necmpi                    # necessary for MPI job
 #PBS -l elapstim_req=00:15:00     # elapsed time limit
 
@@ -57,9 +57,11 @@ MPI_procs=1                       # number of MPI processes (= venode*8 for flat
 
 #PBS -v LANG=C
 
+source /etc/profile.d/modules.sh
+
 #module load NECNLC-sx
 ## module load NECNLC-mpi-sx
-module load fftw-sx netcdf-parallelIO-fortran-sx/4.5.2
+module load fftw-sx netcdf-parallelIO-fortran-sx
 
 
 ### Working directory 

--- a/src/backup/diag_main.f90
+++ b/src/backup/diag_main.f90
@@ -1,0 +1,519 @@
+PROGRAM diag
+!-------------------------------------------------------------------------------
+!
+!     Data diagnostics from binary output
+!                                                   (S. Maeyama, 11 June 2014)
+!
+!-------------------------------------------------------------------------------
+  use diag_header
+  use diag_clock, only : clock_sta, clock_end, elt
+  use diag_geom, only : geom_init
+  use diag_rb, only : loop_phi_sta, loop_phi_end, &
+                      loop_fxv_sta, loop_fxv_end, &
+                      loop_trn_sta, loop_trn_end, &
+                      loop_tri_sta, loop_tri_end, &
+                      loop_cnt_sta, loop_cnt_end, &
+                      num_triad_diag, triad_diag_mxt, triad_diag_myt
+
+  use out_textfile, only : phiintext
+  use out_netcdf, only : phiinnetcdf,  Alinnetcdf, mominnetcdf, &
+                         fxvinnetcdf, cntinnetcdf, trninnetcdf, triinnetcdf
+  use out_linfreq, only : linfreqintime, linfreqinkxky
+  use out_mominfreq, only : phiinfreq
+  use out_mominkxky, only : phiinkxky, Alinkxky, mominkxky
+  use out_trninkxky, only : trninkxky
+  use out_mominxy, only : phiinxy, Alinxy, mominxy,  &
+                          phiinxy_parity, Alinxy_parity, mominxy_parity
+  use out_mominz, only : phiinz, Alinz, mominz, phiinz_freq,                            &
+                         phiinz_connect, Alinz_connect, mominz_connect, eneinz_connect, &
+                         phiinz_parity, phiinz_parity_freq, &
+                         Alinz_parity, Alinz_parity_freq
+  use out_momintky, only : momintky_open, momintky_close,          &
+                           wesintky, wemintky, engintky, menintky, &
+                           wesintky_parity, wemintky_parity, engintky_parity, menintky_parity
+
+  use out_ffinkxky, only : fkinkxky_fxv, fkinkxky_cnt
+  use out_ffinvm, only : fkinvm_fxv, fkinvm_cnt, fluxinvm_fxv, fluxinvm_cnt
+  use out_ffinzv, only : fkinzv
+  use out_ffinzvm_vtk, only : fkinzvm_vtk, fkinzvm_connect_vtk
+
+  use out_mominvtk, only : phiinvtk
+  use out_mominxmf, only : mominxmf_coord, &
+                           mominxmf_var_phi, mominxmf_header_phi, &
+                           mominxmf_var_Al,  mominxmf_header_Al,  &
+                           mominxmf_var_mom, mominxmf_header_mom
+  use out_mominrz, only : phiinrz
+
+  use out_triinkxky, only : triinkxky
+
+  use out_fluidtotaltrans, only : fluidtotaltrans_isloop
+  use out_fluiddetailtrans, only : fluiddetailtrans_mxmyisloop
+
+!!!use out_mominxz, only : phiinxz, Alinxz, mominxz
+!!!use out_triinkxky, only : triinkxky
+!!!use out_mominavs, only : phiinavs
+!!!use out_bicoherence, only : bicoh_phicheck, bicoh_freqcheck, bicoh_bicoherence
+!!!use out_realsp, only : realsp_create
+!!!use out_fluidsubsptrans, only : fluidsubsptrans_izloop, fluidsubsptrans_izloop_open,  &
+!!!                                fluidsubsptrans_izloop_close, fluidsubsptrans_loop,  &
+!!!                                fluidsubsptrans_loop_open, fluidsubsptrans_loop_close
+!!!use out_zfshearing, only : zfs_open, zfs_close, zfshearing, zfshearing_timeaverage
+!!!use out_zfdensity, only : zfd_open, zfd_close, zfdensity
+  implicit none
+
+  real(kind=8) :: trange
+  integer :: mx, gmy, giz, giv, gim, imom, is, &
+             loop, flag, loop_sta, loop_end, loop_skp, it, mxt, myt, rankz
+
+
+!--- Initialize ---
+    call initialize
+    call geom_init( snum )  ! It can be re-called when namelist is changed in runs.
+    trange=0.d0;mx=0;gmy=0;giz=0;giv=0;gim=0;imom=0;is=0
+    loop=0;flag=0;loop_sta=0;loop_end=0;loop_skp=0;it=0;mxt=0;myt=0;rankz=nprocz/2+1
+!------------------
+
+                                                        call clock_sta(10)
+!= example to write NetCDF data format =
+    write(*,*) "OUTPUT : NetCDF data"
+    call phiinnetcdf
+    call  Alinnetcdf
+    call mominnetcdf
+    call fxvinnetcdf
+    call cntinnetcdf
+    call trninnetcdf
+    do it = 0, num_triad_diag-1
+      mxt = triad_diag_mxt(it)
+      myt = triad_diag_myt(it)
+      call triinnetcdf( mxt, myt )
+    end do
+
+!!= example to write linear frequency =
+!    write(*,*) "OUTPUT : linfreqintime* linfreqinkxky*"
+!    mx = 0
+!    gmy = 3
+!    loop_skp = 1
+!    loop_sta = loop_phi_end(enum)/2
+!    loop_end = loop_phi_end(enum)
+!    call linfreqintime( mx, gmy, loop_sta, loop_end, loop_skp )
+!    call linfreqinkxky( loop_end ) ! Evaluate linear dispersion omega(kx,ky)
+!
+!
+!!= example to write moments in freq =
+!    write(*,*) "OUTPUT : phiinfreq*"
+!    mx = 0
+!    gmy = 3
+!    giz = 0
+!    trange = 5._DP
+!    call phiinfreq( mx, gmy, giz, trange )
+!
+!
+!= example to write moments in kxky =
+    write(*,*) "OUTPUT : phiinkxky* Alinkxky* mominkxky*"
+    loop_skp = 10
+    loop_sta = (floor(dble(loop_phi_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_phi_sta(snum)
+    loop_end = loop_phi_end(enum)
+    do loop = loop_sta, loop_end, loop_skp
+      call phiinkxky( loop )
+      call Alinkxky( loop )
+      do is = 0, ns-1
+        call mominkxky( is, loop )
+      end do
+    end do
+
+
+!= example to write entropy balance diagnostics in kxky =
+    write(*,*) "OUTPUT : trninkxky* "
+    loop_skp = 10
+    loop_sta = (floor(dble(loop_trn_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_trn_sta(snum)
+    loop_end = loop_trn_end(enum)
+    do loop = loop_sta, loop_end, loop_skp
+      do is = 0, ns-1
+        call trninkxky( is, loop )
+      end do
+    end do
+
+
+!= example to write moments in xy =
+    write(*,*) "OUTPUT : phiinxy* Alinxy* mominxy*"
+    giz = 0
+    loop_skp = 10
+    loop_sta = (floor(dble(loop_phi_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_phi_sta(snum)
+    loop_end = loop_phi_end(enum)
+    do loop = loop_sta, loop_end, loop_skp
+      call phiinxy( giz, loop )
+      call Alinxy( giz, loop )
+      do is = 0, ns-1
+        call mominxy( giz, is, loop )
+      end do
+    end do
+    !do loop = loop_sta, loop_end, loop_skp
+    !  call phiinxy_parity( giz, loop )
+    !  call Alinxy_parity( giz, loop )
+    !  do is = 0, ns-1
+    !    call mominxy_parity( giz, is, loop )
+    !  end do
+    !end do
+
+
+!= example to write moments in zz =
+    write(*,*) "OUTPUT : phiinz* Alinz* mominz*"
+    mx = 0
+    gmy = 6
+    loop_skp = 10
+    loop_sta = (floor(dble(loop_phi_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_phi_sta(snum)
+    loop_end = loop_phi_end(enum)
+    do loop = loop_sta, loop_end, loop_skp
+!      call phiinz( mx, gmy, loop )
+      call phiinz_connect( mx, gmy, loop )
+!      call Alinz( mx, gmy, loop )
+      call Alinz_connect( mx, gmy, loop )
+      do is = 0, ns-1
+!        call mominz( mx, gmy, is, loop )
+        call mominz_connect( mx, gmy, is, loop )
+      end do
+!      call eneinz_connect( mx, gmy, loop )
+    end do
+!    call phiinz_freq( mx, gmy )
+!    do loop = loop_sta, loop_end, loop_skp
+!      call phiinz_parity( mx, gmy, loop )
+!      call Alinz_parity( mx, gmy, loop )
+!    end do
+!    call phiinz_parity_freq( mx, gmy )
+!    call Alinz_parity_freq( mx, gmy )
+
+
+!!= example to write moments in tky =
+!    write(*,*) "OUTPUT : momintky* "
+!    loop_skp = 10
+!    loop_sta = (floor(dble(loop_phi_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_phi_sta(snum)
+!    loop_end = loop_phi_end(enum)
+!    call momintky_open( "./data/wesintky_parity.dat" )
+!    do loop = loop_sta, loop_end, loop_skp
+!      call wesintky_parity( loop )
+!    end do
+!    call momintky_close
+!    call momintky_open( "./data/wemintky_parity.dat" )
+!    do loop = loop_sta, loop_end, loop_skp
+!      call wemintky_parity( loop )
+!    end do
+!    call momintky_close
+!    call momintky_open( "./data/engintky_parity.dat" )
+!    do loop = loop_sta, loop_end, loop_skp
+!      call engintky_parity( loop )
+!    end do
+!    call momintky_close
+!    call momintky_open( "./data/menintky_parity.dat" )
+!    do loop = loop_sta, loop_end, loop_skp
+!      call menintky_parity( loop )
+!    end do
+!    call momintky_close
+!
+!
+!!= example to write ff in kxky =
+!    write(*,*) "OUTPUT : fkinkxky*"
+!    != read from fxv/*fxv* =
+!    rankz = nprocz/2
+!    giv = 8
+!    gim = 4
+!    loop_skp = 10
+!    loop_sta = (floor(dble(loop_fxv_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_fxv_sta(snum)
+!    loop_end = loop_fxv_end(enum)
+!    do loop = loop_sta, loop_end, loop_skp
+!      do is = 0, ns-1
+!        call fkinkxky_fxv( rankz, giv, gim, is, loop )
+!      end do
+!    end do
+!    != read from cnt/*cnt* =
+!    !giz = 0
+!    !giv = 8
+!    !gim = 4
+!    !loop_skp = 10
+!    !loop_sta = (floor(dble(loop_cnt_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_cnt_sta(snum)
+!    !loop_end = loop_cnt_end(enum)
+!    !do loop = loop_sta, loop_end, loop_skp
+!    !  do is = 0, ns-1
+!    !    call fkinkxky_cnt( giz, giv, gim, is, loop )
+!    !  end do
+!    !end do
+!    
+!
+!!= example to write ff in vm =
+!    write(*,*) "OUTPUT : fkinvm*"
+!    != read from fxv/*fxv* =
+!    mx = 0
+!    gmy = 1
+!    rankz = nprocz/2
+!    loop_skp = 10
+!    loop_sta = (floor(dble(loop_fxv_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_fxv_sta(snum)
+!    loop_end = loop_fxv_end(enum)
+!    do loop = loop_sta, loop_end, loop_skp
+!      do is = 0, ns-1
+!        call fkinvm_fxv( mx, gmy, rankz, is, loop )
+!        call fluxinvm_fxv( rankz, is, loop )
+!      end do
+!    end do
+!    != read from cnt/*cnt* =
+!    !mx = 0
+!    !gmy = 3
+!    !giz = 0
+!    !loop_skp = 10
+!    !loop_sta = (floor(dble(loop_cnt_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_cnt_sta(snum)
+!    !loop_end = loop_cnt_end(enum)
+!    !do loop = loop_sta, loop_end, loop_skp
+!    !  do is = 0, ns-1
+!    !    call fkinvm_cnt( mx, gmy, giz, is, loop )
+!    !    call fluxinvm_cnt( giz, is, loop )
+!    !  end do
+!    !end do
+!
+!
+!!= example to write ff in zv =
+!    write(*,*) "OUTPUT : fkinzv*"
+!    != read from cnt/*cnt* =
+!    mx = 0
+!    gmy = 3
+!    gim = 4
+!    loop_skp = 10
+!    loop_sta = (floor(dble(loop_cnt_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_cnt_sta(snum)
+!    loop_end = loop_cnt_end(enum)
+!    do loop = loop_sta, loop_end, loop_skp
+!      do is = 0, ns-1
+!        !do gim = 0, global_nm, (global_nm+1)/4
+!          call fkinzv( mx, gmy, gim, is, loop )
+!        !end do
+!      end do
+!    end do
+!
+!
+!!= example to write ff in zvm =
+!    write(*,*) "OUTPUT : fkinzvm*"
+!    != read from cnt/*cnt* =
+!    mx = 0
+!    gmy = 1
+!    loop_skp = 10
+!    loop_sta = (floor(dble(loop_cnt_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_cnt_sta(snum)
+!    loop_end = loop_cnt_end(enum)
+!    do is = 0, ns-1
+!      call fkinzvm_vtk( mx, gmy, is, loop_sta, loop_end, loop_skp )
+!      !call fkinzvm_connect_vtk( mx, gmy, is, loop_sta, loop_end, loop_skp )
+!    end do
+!
+!
+!= example to write moments in xyz =
+    write(*,*) "OUTPUT : phiinxmf* "
+    loop_skp = max(1, (loop_phi_end(enum) - loop_phi_sta(snum))/100)
+    loop_sta = (floor(dble(loop_phi_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_phi_sta(snum)
+    loop_end = loop_phi_end(enum)
+    !- XDFM (.xmf) file describes treatment of binary data, in extensible Markup Language (XML).
+    call mominxmf_coord                                      ! output coordinate binary
+    call mominxmf_var_phi( loop_sta, loop_end, loop_skp )    ! output phi binary
+    call mominxmf_header_phi( loop_sta, loop_end, loop_skp ) ! output phiinxmf_header_*.xmf
+    !call mominxmf_var_Al( loop_sta, loop_end, loop_skp )     ! output Al binary
+    !call mominxmf_header_Al( loop_sta, loop_end, loop_skp )  ! output Alinxmf_header_*.xmf
+    !do is = 0, ns-1
+    !  do imom = 0, nmom-1
+    !    call mominxmf_var_mom( imom, is, loop_sta, loop_end, loop_skp ) ! output mom binary
+    !    call mominxmf_header_mom( imom, is, loop_sta, loop_end, loop_skp ) 
+    !                                                         ! output mominxmf_header_*.xmf
+    !  end do
+    !end do
+!!
+!!    !- Output XML-based VTK format is also available -
+!!    flag=1; call phiinvtk( flag, loop_sta, loop_end, loop_skp )  ! output coord&var(fluxtube)
+!!    flag=3; call phiinvtk( flag, loop_sta, loop_end, loop_skp )  ! output coord&var(full torus)
+!!    flag=5; call phiinvtk( flag, loop_sta, loop_end, loop_skp )  ! output coord&var(field aligned)
+!!
+!
+!= example to write moments in xy =
+    write(*,*) "OUTPUT : phiinrz* "
+    loop_skp = 10
+    loop_sta = (floor(dble(loop_phi_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_phi_sta(snum)
+    loop_end = loop_phi_end(enum)
+    do loop = loop_sta, loop_end, loop_skp
+      call phiinrz( loop )
+    end do
+
+
+!!= example to write triad transfer diagnostics in kxky =
+!    write(*,*) "OUTPUT : triinkxky* "
+!    loop_skp = 10
+!    loop_sta = (floor(dble(loop_tri_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_tri_sta(snum)
+!    loop_end = loop_tri_end(enum)
+!    do loop = loop_sta, loop_end, loop_skp
+!      do is = 0, ns-1
+!        do it = 0, num_triad_diag-1
+!          mxt = triad_diag_mxt(it)
+!          myt = triad_diag_myt(it)
+!          call triinkxky( mxt, myt, is, loop )
+!        end do
+!      end do
+!    end do
+!
+!
+!!= example to write total triad transfer in fluid approximation =
+!    write(*,*) "OUTPUT : fluidtotaltransinkxky* "
+!    loop_skp = max(1, (loop_phi_end(enum) - loop_phi_sta(snum))/100)
+!    loop_sta = (floor(dble(loop_phi_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_phi_sta(snum)
+!    loop_end = loop_phi_end(enum)
+!    do loop = loop_sta, loop_end, loop_skp
+!      do is = 0, ns-1
+!        call fluidtotaltrans_isloop( is, loop )
+!      end do
+!    end do
+!
+!
+!!= example to write detailed triad transfer in fluid approximation =
+!    write(*,*) "OUTPUT : fluiddetailtransinkxky* "
+!    loop_skp = max(1, (loop_phi_end(enum) - loop_phi_sta(snum))/100)
+!    loop_sta = (floor(dble(loop_phi_sta(snum)-1)/loop_skp)+1)*loop_skp ! loop_phi_sta(snum)
+!    loop_end = loop_phi_end(enum)
+!    do loop = loop_sta, loop_end, loop_skp
+!      do is = 0, ns-1
+!        call fluiddetailtrans_mxmyisloop(diag_mx=0, diag_my=2, is=is, loop=loop )
+!!        call fluiddetailtrans_mxmyisloop(diag_mx=1, diag_my=0, is=is, loop=loop )
+!      end do
+!    end do
+
+
+
+
+!!!
+!!!  != example to write moments in xz =
+!!!    gmy=3
+!!!    do loop = loop_phi_sta(snum), loop_phi_end(enum), 1
+!!!      call phiinxz( gmy, loop )
+!!!      call Alinxz( gmy, loop )
+!!!      do is = 0, ns-1
+!!!        do imom = 0, nmom-1
+!!!          call mominxz( gmy, imom, is, loop )
+!!!        end do
+!!!      end do
+!!!    end do
+!!!
+!!!
+!!!  != example to write auto bicoherence in frequency space =
+!!!  ! call realsp_create( 0, 1999, 2002 )  ! create data for bicoherence analysis
+!!!  ! call bicoh_phicheck( 2000 )
+!!!  ! call bicoh_freqcheck( 0, 0, 10._DP )
+!!!  ! call bicoh_bicoherence( 5._DP, 10._DP )
+!!!
+!!!
+!!!  != example to write subspace transfer in fluid approximation =
+!!!  ! giz = 0
+!!!  ! loop_sta = loop_phi_sta(snum); loop_end = loop_phi_end(enum);
+!!!  ! loop_skp = max(1, (loop_end - loop_sta)/100)
+!!!  ! call fluidsubsptrans_loop_open
+!!!  ! do loop = loop_sta, loop_end, loop_skp
+!!!  !   call fluidsubsptrans_loop( loop )
+!!!  ! end do
+!!!  ! call fluidsubsptrans_loop_close
+!!!    
+!!!
+!!!  != example to write zonal flow shearing rate =
+!!!  ! call zfs_open
+!!!  ! loop_sta = loop_phi_sta(snum); loop_end = loop_phi_end(enum);
+!!!  ! loop_skp = max(1, (loop_end - loop_sta)/100)
+!!!  ! do loop = loop_sta, loop_end, loop_skp
+!!!  !   call zfshearing( loop )
+!!!  ! end do
+!!!  ! call zfs_close
+!!!  ! call zfshearing_timeaverage( 5000, 9000, 100 )
+!!!  ! call zfshearing_timeaverage( 880, 1280, 10 )
+!!!
+!!!
+!!!  != example to write zonal fluctuations =
+!!!  ! call zfd_open
+!!!  ! loop_sta = loop_phi_sta(snum); loop_end = loop_phi_end(enum);
+!!!  ! loop_skp = max(1, (loop_end - loop_sta)/100)
+!!!  ! do loop = loop_sta, loop_end, loop_skp
+!!!  !   call zfdensity( loop )
+!!!  ! end do
+!!!  ! call zfd_close
+
+
+                                                        call clock_end(10)
+
+
+!--- Finalization ---
+    call finalize
+    write( *, * ) ""
+    write( *, * ) "########## elapsed time (sec) #########"
+    write( *, * ) "# total = ", elt(10)
+    write( *, * ) "#######################################"
+!---------------------
+
+
+END PROGRAM diag
+
+
+SUBROUTINE initialize
+!-------------------------------------------------------------------------------
+!
+!     Initialize diag
+!                                                   (S. Maeyama, 9 Dec. 2016)
+!
+!-------------------------------------------------------------------------------
+  use diag_clock, only : clock_init
+  use diag_rb, only : rb_phi_fileopen, rb_phi_check, rb_phi_setnloop,  &
+                      rb_Al_fileopen,  rb_Al_check,  rb_Al_setnloop,   &
+                      rb_mom_fileopen, rb_mom_check, rb_mom_setnloop,  &
+                      rb_trn_fileopen, rb_trn_check, rb_trn_setnloop,  &
+                      rb_tri_fileopen, rb_tri_check, rb_tri_setnloop,  &
+                      rb_fxv_fileopen, rb_fxv_check, rb_fxv_setnloop,  &
+                      rb_cnt_fileopen, rb_cnt_check, rb_cnt_setnloop
+  use diag_fft, only : fft_pre
+  implicit none
+
+    call clock_init
+    call rb_phi_fileopen
+    call rb_phi_check
+    call rb_phi_setnloop
+    call rb_Al_fileopen
+    call rb_Al_check
+    call rb_Al_setnloop
+    call rb_mom_fileopen
+    call rb_mom_check
+    call rb_mom_setnloop
+    call rb_trn_fileopen
+    call rb_trn_check
+    call rb_trn_setnloop
+    call rb_tri_fileopen
+    call rb_tri_check
+    call rb_tri_setnloop
+    call rb_fxv_fileopen
+    call rb_fxv_check
+    call rb_fxv_setnloop
+    call rb_cnt_fileopen
+    call rb_cnt_check
+    call rb_cnt_setnloop
+    call fft_pre
+
+END SUBROUTINE initialize
+
+
+SUBROUTINE finalize
+!-------------------------------------------------------------------------------
+!
+!     Finalize diag
+!                                                   (S. Maeyama, 9 Dec. 2016)
+!
+!-------------------------------------------------------------------------------
+  use diag_rb, only : rb_phi_fileclose,  &
+                      rb_Al_fileclose,   &
+                      rb_mom_fileclose,  &
+                      rb_trn_fileclose,  &
+                      rb_tri_fileclose,  &
+                      rb_fxv_fileclose,  &
+                      rb_cnt_fileclose
+  implicit none
+
+    call rb_phi_fileclose
+    call rb_Al_fileclose
+    call rb_mom_fileclose
+    call rb_trn_fileclose
+    call rb_tri_fileclose
+    call rb_fxv_fileclose
+    call rb_cnt_fileclose
+
+END SUBROUTINE finalize

--- a/src/backup/diag_main_chgres_fort.f90
+++ b/src/backup/diag_main_chgres_fort.f90
@@ -1,0 +1,100 @@
+PROGRAM diag
+!-------------------------------------------------------------------------------
+!
+!     Data diagnostics from binary output
+!     Test for chgres_cnt
+!
+!-------------------------------------------------------------------------------
+  use diag_header
+  use diag_clock, only : clock_sta, clock_end, elt
+  use diag_geom, only : geom_init
+  use diag_rb, only : loop_cnt_sta, loop_cnt_end
+
+  use out_netcdf, only : cntinnetcdf
+  use diag_chgres_cnt
+
+  implicit none
+
+  real(kind=8) :: trange
+  integer :: mx, gmy, giz, giv, gim, imom, is, &
+             loop, flag, loop_sta, loop_end, loop_skp, it, mxt, myt, rankz
+
+  integer :: stpn, nnx, ngy, ngz, ngv, ngm, nnpw, nnpz, nnpv, nnpm, nnps
+  !character(len=*) :: outdir
+
+
+!--- Initialize ---
+    call initialize
+    call geom_init( snum )  ! It can be re-called when namelist is changed in runs.
+    trange=0.d0;mx=0;gmy=0;giz=0;giv=0;gim=0;imom=0;is=0
+    loop=0;flag=0;loop_sta=0;loop_end=0;loop_skp=0;it=0;mxt=0;myt=0;rankz=nprocz/2+1
+!------------------
+
+                                                        call clock_sta(10)
+!= example to write NetCDF data format =
+!    write(*,*) "OUTPUT : NetCDF data"
+!    call cntinnetcdf
+
+    
+!--- Change resolution ---
+    nnx = nx
+    ngy = global_ny
+    ngz = global_nz
+    ngv = global_nv
+    ngm = global_nm
+    nnpw= nprocw
+    nnpz= nprocz
+    nnpv= nprocv
+    nnpm= nprocm
+    nnps= nprocs
+    
+    call chgres_cnt_fortran(nnx=nnx, ngy=ngy, ngz=ngz, ngv=ngv, ngm=ngm, &
+        nnpw=nnpw, nnpz=nnpz, nnpv=nnpv, nnpm=nnpm, nnps=nnps)
+!------------------
+                                                        call clock_end(10)
+
+
+!--- Finalization ---
+    call finalize
+    write( *, * ) ""
+    write( *, * ) "########## elapsed time (sec) #########"
+    write( *, * ) "# total = ", elt(10)
+    write( *, * ) "#######################################"
+!---------------------
+
+
+END PROGRAM diag
+
+
+SUBROUTINE initialize
+!-------------------------------------------------------------------------------
+!
+!     Initialize diag
+!                                                   (S. Maeyama, 9 Dec. 2016)
+!
+!-------------------------------------------------------------------------------
+  use diag_clock, only : clock_init
+  use diag_rb, only : rb_cnt_fileopen, rb_cnt_check, rb_cnt_setnloop
+  implicit none
+
+    call clock_init
+    call rb_cnt_fileopen
+    call rb_cnt_check
+    call rb_cnt_setnloop
+
+END SUBROUTINE initialize
+
+
+SUBROUTINE finalize
+!-------------------------------------------------------------------------------
+!
+!     Finalize diag
+!                                                   (S. Maeyama, 9 Dec. 2016)
+!
+!-------------------------------------------------------------------------------
+  use diag_rb, only : rb_cnt_fileclose
+  implicit none
+
+    call rb_cnt_fileclose
+
+END SUBROUTINE finalize

--- a/src/backup/diag_main_chgres_netcdf.f90
+++ b/src/backup/diag_main_chgres_netcdf.f90
@@ -1,0 +1,100 @@
+PROGRAM diag
+!-------------------------------------------------------------------------------
+!
+!     Data diagnostics from binary output
+!     Test for chgres_cnt
+!
+!-------------------------------------------------------------------------------
+  use diag_header
+  use diag_clock, only : clock_sta, clock_end, elt
+  use diag_geom, only : geom_init
+  use diag_rb, only : loop_cnt_sta, loop_cnt_end
+
+  use out_netcdf, only : cntinnetcdf
+  use diag_chgres_cnt
+
+  implicit none
+
+  real(kind=8) :: trange
+  integer :: mx, gmy, giz, giv, gim, imom, is, &
+             loop, flag, loop_sta, loop_end, loop_skp, it, mxt, myt, rankz
+
+  integer :: stpn, nnx, ngy, ngz, ngv, ngm, nnpw, nnpz, nnpv, nnpm, nnps
+  !character(len=*) :: outdir
+
+
+!--- Initialize ---
+    call initialize
+    call geom_init( snum )  ! It can be re-called when namelist is changed in runs.
+    trange=0.d0;mx=0;gmy=0;giz=0;giv=0;gim=0;imom=0;is=0
+    loop=0;flag=0;loop_sta=0;loop_end=0;loop_skp=0;it=0;mxt=0;myt=0;rankz=nprocz/2+1
+!------------------
+
+                                                        call clock_sta(10)
+!= example to write NetCDF data format =
+!    write(*,*) "OUTPUT : NetCDF data"
+!    call cntinnetcdf
+
+    
+!--- Change resolution ---
+    nnx = nx
+    ngy = global_ny
+    ngz = global_nz
+    ngv = global_nv
+    ngm = global_nm
+    nnpw= nprocw
+    nnpz= nprocz
+    nnpv= nprocv
+    nnpm= nprocm
+    nnps= nprocs
+    
+    call chgres_cnt_netcdf(nnx=nnx, ngy=ngy, ngz=ngz, ngv=ngv, ngm=ngm, &
+        nnpw=nnpw, nnpz=nnpz, nnpv=nnpv, nnpm=nnpm, nnps=nnps)
+!------------------
+                                                        call clock_end(10)
+
+
+!--- Finalization ---
+    call finalize
+    write( *, * ) ""
+    write( *, * ) "########## elapsed time (sec) #########"
+    write( *, * ) "# total = ", elt(10)
+    write( *, * ) "#######################################"
+!---------------------
+
+
+END PROGRAM diag
+
+
+SUBROUTINE initialize
+!-------------------------------------------------------------------------------
+!
+!     Initialize diag
+!                                                   (S. Maeyama, 9 Dec. 2016)
+!
+!-------------------------------------------------------------------------------
+  use diag_clock, only : clock_init
+  use diag_rb, only : rb_cnt_fileopen, rb_cnt_check, rb_cnt_setnloop
+  implicit none
+
+    call clock_init
+    call rb_cnt_fileopen
+    call rb_cnt_check
+    call rb_cnt_setnloop
+
+END SUBROUTINE initialize
+
+
+SUBROUTINE finalize
+!-------------------------------------------------------------------------------
+!
+!     Finalize diag
+!                                                   (S. Maeyama, 9 Dec. 2016)
+!
+!-------------------------------------------------------------------------------
+  use diag_rb, only : rb_cnt_fileclose
+  implicit none
+
+    call rb_cnt_fileclose
+
+END SUBROUTINE finalize

--- a/src/diag_chgres_cnt.f90
+++ b/src/diag_chgres_cnt.f90
@@ -1,0 +1,706 @@
+!-------------------------------------------------------------------------------
+!
+!    diag_chgres_cnt: change the resolution and process division number for cnt
+!                                                   (FUJITSU LTD, November 2021)
+!
+!-------------------------------------------------------------------------------
+MODULE diag_chgres_cnt
+  use diag_header
+  use diag_rb, only : rb_cnt_gettime, rb_cnt_ivimisloop, &
+       loop_cnt_sta, loop_cnt_end
+  use diag_geom, only : lz, vmax, mmax, dz, dv, dm, kxmin, kymin
+  use diag_interp
+  use diag_cache_cnt
+  use netcdf
+  implicit none
+
+  private renew_dir, check_params, get_org_ivim, check_nf90err
+  integer, parameter :: cntfos = 900000000
+
+  public  chgres_cnt_fortran , chgres_cnt_netcdf
+
+    
+CONTAINS
+
+  !-------------------------------------------------------------------------
+  ! renew_dir: renewal output directory
+  !-------------------------------------------------------------------------
+  SUBROUTINE renew_dir( dir )
+    character(len=*), intent(in) :: dir
+    character(len=512) :: comm
+    integer :: status
+
+    write(comm, *) 'if [ -d ', trim(dir), ' ]; then rm -rf ', trim(dir), '; fi'
+    call system(comm, status)
+    if ( status /= 0 ) then
+       write(*,*) "chgres_cnt: system exec failed: ", comm
+       stop
+    end if
+
+    write(comm, *) 'mkdir -p ', trim(dir)
+    call system(comm, status)
+    if ( status /= 0 ) then
+       write(*,*) "chgres_cnt: mkdir failed: ", trim(dir)
+       stop
+    end if
+
+    return
+  end SUBROUTINE renew_dir
+
+  !-------------------------------------------------------------------------
+  ! check_params: check parameters
+  !-------------------------------------------------------------------------
+  SUBROUTINE check_params(nnx, ngy, ngz, ngv, ngm, nnpw, nnpz, nnpv, nnpm, nnps)
+    integer, intent(in) :: nnx, ngy, ngz, ngv, ngm, nnpw, nnpz, nnpv, nnpm, nnps
+    integer :: wny
+
+!<-S.Maeyama(13 March 2022)
+    !if ( nnx < 1 .or. ngy < 1 .or. ngz < 1 .or. ngv < 1 .or. ngm < 1 .or. &
+    !     nnpw < 1 .or. nnpz < 1 .or. nnpv < 1 .or. nnpm < 1 .or. nnps < 1 ) then
+!% Extention for nx=0 in old file
+    if ( nnx < 0 .or. ngy < 1 .or. ngz < 1 .or. ngv < 1 .or. ngm < 1 .or. &
+         nnpw < 1 .or. nnpz < 1 .or. nnpv < 1 .or. nnpm < 1 .or. nnps < 1 ) then
+!>
+       write(*,*) "chgres_cnt: negative or zero value has specified."
+       stop
+    end if
+    wny = ngy / nnpw
+    if ( wny < 1 .or. ((wny+1)*nnpw - ngy -1)/(wny+1) > 1 ) then
+       write(*,*) "chgres_cnt: invalid ngy or nnpw has specified."
+       stop
+    end if
+    if ( real(ngz)/real(nnpz) /= real(ngz/nnpz) ) then
+       write(*,*) "chgres_cnt: invalid ngz or nnpz has specified."
+       stop
+    end if
+    if ( real(ngv)/real(nnpv) /= real(ngv/nnpv) ) then
+       write(*,*) "chgres_cnt: invalid ngv or nnpv has specified."
+       stop
+    end if
+    if ( real(ngm+1)/real(nnpm) /= real((ngm+1)/nnpm) .or. &
+         (ngm+1)/nnpm -1 < 1 ) then
+       write(*,*) "chgres_cnt: invalid ngm or nnpm has specified."
+       stop
+    end if
+    return
+  end SUBROUTINE check_params
+
+  !-------------------------------------------------------------------------
+  ! get_org_ivim: get indices range of v and m in original mesh
+  !-------------------------------------------------------------------------
+  SUBROUTINE get_org_ivim(v, m, oiv, oim, vflag, mflag)
+    real(kind=DP), intent(in) :: v, m
+    integer, dimension(2), intent(out) :: oiv, oim
+    integer, optional, intent(out) :: vflag, mflag
+    integer :: i
+
+    ! indices of v
+    if ( v < -vmax ) then ! equivalent to (i == 1)
+       oiv(1) = 1; oiv(2) = 2
+       if ( present(vflag) ) vflag = -1
+    else if ( v > vmax ) then
+       oiv(2) = 2 * global_nv; oiv(1) = oiv(2) -1
+       if ( present(vflag) ) vflag = 1
+    else
+       if ( present(vflag) ) vflag = 0
+       do i = 2, 2*global_nv
+          if ( v < -vmax + (i-1)*dv ) then
+             oiv(1) = i -1; oiv(2) = i
+             exit
+          end if
+       end do
+    end if
+
+    ! indices of m
+    if ( m < 0 ) then ! equivalent to (i == 0)
+       oim(1) = 0; oim(2) = 1
+       if ( present(mflag) ) mflag = -1
+    else if ( m > mmax ) then
+       oim(2) = global_nm; oim(1) = oim(2) -1
+       if ( present(mflag) ) mflag = 1
+    else
+       if ( present(mflag) ) mflag = 0
+       do i = 1, global_nm
+          if ( m < i*dm ) then
+             oim(1) = i -1; oim(2) = i
+             exit
+          end if
+       end do
+    end if
+
+    return
+  end SUBROUTINE get_org_ivim
+
+  !-------------------------------------------------------------------------
+  ! check_nf90err: check error message of nf90 (copied from out_netcdf.f90)
+  !-------------------------------------------------------------------------
+  SUBROUTINE check_nf90err(werr, comment)
+    integer(kind=4), intent(in) :: werr
+    character(len=*), intent(in) :: comment
+    if(werr /= nf90_noerr) then
+       write(*,*) comment//" "//trim(nf90_strerror(werr))
+       stop
+    end if
+  END SUBROUTINE check_nf90err
+
+
+!-------------------------------------------------------------------------------
+!
+!    change the resolution and process division number for cnt
+!    and write into Fortran I/O files
+!                                                   (FUJITSU LTD, November 2021)
+!
+!-------------------------------------------------------------------------------
+  SUBROUTINE chgres_cnt_fortran( stpn, nnx, ngy, ngz, ngv, ngm, &
+       nnpw, nnpz, nnpv, nnpm, nnps, outdir )
+    integer, optional, intent(in) :: stpn, nnx, ngy, ngz, ngv, ngm, &
+         nnpw, nnpz, nnpv, nnpm, nnps
+    character(len=*), optional, intent(in) :: outdir
+
+    integer :: n_nx, n_gy, n_gz, n_gv, n_gm, n_npw, n_npz, n_npv, n_npm, n_nps
+    integer :: n_ny, n_nz, n_nv, n_nm
+    integer :: stpnum, ips, ipm, ipv, ipz, ipw, loop
+    integer :: igx0, igy0, igz0, igv0, igm0, igx1, igy1, igz1, igv1, igm1
+    integer :: igx, igy, igz, igv, igm, ir, oiz, oiv(2), oim(2)
+    real(kind=DP) :: time, z0, v0, m0, z1, v1, m1, n_dm, n_dv, n_dz
+    real(kind=DP) :: xx, yy, zz, vv, mm
+    complex(kind=DP) :: f
+    ! buffer for write to file
+    complex(kind=DP), dimension(:,:,:,:,:), allocatable :: nff
+    ! buffer for rb_cnt_ivimisloop (v=2, m=2)
+    complex(kind=DP), target :: &
+         off(2*nx +1, global_ny +1, 2*global_nz, 2, 2)
+    !     off(-nx:nx, 0:global_ny, -global_nz:global_nz-1, 2, 2)
+    complex(kind=DP) :: woff(2*nx +1, global_ny +1, 2*global_nz)
+    !complex(kind=DP) :: woff(-nx:nx, 0:global_ny, -global_nz:global_nz-1)
+    character(len=*), parameter :: default_odir = "./chgres_cnt"
+    character(len=512) :: odir
+    character(len=6) :: crank
+    character(len=3) :: cnum
+    ! 5d complex interpolator
+    type(interp_5d) :: intp5d
+
+    ! check stpnum
+    stpnum = merge(stpn, enum, present(stpn))
+    if (stpnum < snum .or. stpnum > enum) then
+       write(*,*) "chgres_cnt_fortran: invalid stpnum specified(out of range)"
+       stop
+    end if
+
+    ! check new resolution and process division number
+    n_nx = merge(nnx, nx, present(nnx))
+    n_gy = merge(ngy, global_ny, present(ngy))
+    n_gz = merge(ngz, global_nz, present(ngz))
+    n_gv = merge(ngv, global_nv, present(ngv))
+    n_gm = merge(ngm, global_nm, present(ngm))
+    n_npw = merge(nnpw, nprocw, present(nnpw))
+    n_npz = merge(nnpz, nprocz, present(nnpz))
+    n_npv = merge(nnpv, nprocv, present(nnpv))
+    n_npm = merge(nnpm, nprocm, present(nnpm))
+    n_nps = merge(nnps, nprocs, present(nnps))
+    call check_params(n_nx,n_gy,n_gz,n_gv,n_gm, n_npw,n_npz,n_npv,n_npm,n_nps)
+    n_ny = n_gy / n_npw
+    n_nz = n_gz / n_npz
+    n_nv = n_gv / n_npv
+    n_nm = (n_gm + 1) / n_npm - 1
+
+!<-S.Maeyama(13 March 2022)
+    !! prepare directory for fortran files
+    !if ( present(outdir) ) then
+    !   odir = outdir
+    !else
+    !   odir = default_odir
+    !end if
+    !call renew_dir( odir )
+!% At present, renewing output directory cause segmentation falut 
+!% in Plasma simulator. So, output directory is fixed to "./data"
+    odir = "./data"
+!>
+
+    ! allocate work for new cnt
+    !allocate( nff(-n_nx:n_nx, 0:n_ny, -n_nz:n_nz-1, 1:2*n_nv, 0:n_nm) )
+    allocate( nff(2*n_nx+1, n_ny+1, 2*n_nz, 2*n_nv, n_nm+1) )
+
+    ! new delta (z, v, m)
+    n_dz = lz / real(ngz, kind=DP)
+    n_dv = 2._DP * vmax / real(2 * n_nv * n_npv -1, kind=DP)
+    n_dm = mmax / real(n_npm * (n_nm+1) -1, kind=DP)
+
+    ! setup interpolator with original mesh
+    call intp5d%initialize(nx*2+1, global_ny+1, global_nz*2, 2, 2)
+    do oiz = 0, 2*global_nz-1
+       intp5d%z(oiz+1) = -lz + dz*oiz
+    end do
+    
+    ! main loop (in new process division)
+    do loop = loop_cnt_sta(stpnum), loop_cnt_end(stpnum)
+       ! get time
+       call rb_cnt_gettime(loop, time)
+       
+       do ips = 0, n_nps-1
+          
+       ! initialize buffer cache
+       call initialize_cache(ips, loop, 2*n_nv *3)
+          
+       do ipm = 0, n_npm-1
+       do ipv = 0, n_npv-1
+       do ipz = 0, n_npz-1
+       do ipw = 0, n_npw-1
+          nff(:, :, :, :, :) = (0.0, 0.0)
+
+          ! setup rank and loop number string
+          ir = ipw + n_npw*ipz + n_npw*n_npz*ipv &
+               + n_npw*n_npz*n_npv*ipm + n_npw*n_npz*n_npv*n_npm*ips
+          write(crank, fmt="(i6.6)") ir
+          write(cnum, fmt="(i3.3)" ) stpnum
+
+          ! case of extends 's'
+          if ( ips >= nprocs ) then
+             ! open FortranI/O file
+             open(unit=cntfos, &
+                  file=trim(odir)//"/gkvp."//crank//".cnt."//cnum, &
+                  form="unformatted")
+
+             ! write into FortranI/O file
+             rewind cntfos
+             write(unit=cntfos) time, nff
+
+             ! close the file
+             call flush(cntfos)
+             close(cntfos)
+             cycle
+          end if
+
+          ! new index range in global
+          igx0 = -n_nx; igx1 = n_nx
+          igy0 = ipw*(n_ny+1); igy1 = min(igy0+n_ny, n_gy)
+          igz0 = -n_gz + ipz*2*n_nz; igz1 = igz0 + 2*n_nz -1
+          igv0 = 1 + ipv*2*n_nv; igv1 = igv0 + 2*n_nv -1
+          igm0 = ipm*(n_nm+1); igm1 = igm0 + n_nm
+
+          ! new coordinate range (z, v, m)
+          z0 = igz0 * n_dz; z1 = igz1 * n_dz
+          v0 = -vmax + (igv0-1)*n_dv; v1 = -vmax + (igv1-1)*n_dv
+          m0 = igm0 * n_dm; m1 = igm1 * n_dm
+
+          ! in process loop
+          do igm = igm0, igm1
+             mm = m0 + (igm-igm0)*n_dm
+             do igv = igv0, igv1
+                vv = v0 + (igv-igv0)*n_dv
+                
+                ! get original indices around (v, m)
+                call get_org_ivim(vv, mm, oiv, oim)
+
+                ! get off(:, :, :, 1:2, 1:2) around (v, m)
+                ! (v, m) = (1, 1)
+                call get_blk(oiv(1), oim(1), woff)
+                off(:, :, :, 1, 1) = woff
+                ! (v, m) = (2, 1)
+                call get_blk(oiv(2), oim(1), woff)
+                off(:, :, :, 2, 1) = woff
+                ! (v, m) = (1, 2)
+                call get_blk(oiv(1), oim(2), woff)
+                off(:, :, :, 1, 2) = woff
+                ! (v, m) = (2, 2)
+                call get_blk(oiv(2), oim(2), woff)
+                off(:, :, :, 2, 2) = woff
+
+                ! setup interpolator
+                intp5d%v(1) = -vmax + dv * (oiv(1)-1)
+                intp5d%v(2) = -vmax + dv * (oiv(2)-1)
+                intp5d%m(1) = dm * oim(1)
+                intp5d%m(2) = dm * oim(2)
+                intp5d%f => off
+
+                ! interplation loop
+                do igz = igz0, igz1
+                   zz = z0 + (igz-igz0)*n_dz
+                   do igy = igy0, igy1
+                      ! case of extends 'y'
+!<-S.Maeyama(13 March 2022)
+                      !if ( igy > global_nz ) then
+!% Fix a bug
+                      if ( igy > global_ny ) then
+!>
+                         do igx = igx0, igx1
+                            nff(igx-igx0+1, igy-igy0+1, igz-igz0+1, &
+                                 igv-igv0+1, igm-igm0+1) = (0.0, 0.0)
+                         end do
+                         cycle
+                      end if
+                      yy = real(igy)
+                      do igx = igx0, igx1
+                         ! case of extends 'x'
+                         if ( igx < -nx .or. igx > nx ) then
+                            f = (0.0, 0.0)
+                         else
+                            xx = real(igx)
+                            call intp5d%interpolate(xx, yy, zz, vv, mm, f)
+                         end if
+                         nff(igx-igx0+1, igy-igy0+1, igz-igz0+1, &
+                              igv-igv0+1, igm-igm0+1) = f
+                      end do
+                   end do
+                end do
+
+             end do ! igv
+          end do ! igm
+
+          ! open FortranI/O file
+          open(unit=cntfos, &
+               file=trim(odir)//"/gkvp."//crank//".cnt."//cnum, &
+               form="unformatted")
+
+          ! write into FortranI/O file
+          rewind cntfos
+          write(unit=cntfos) time, nff
+
+          ! close the file
+          call flush(cntfos)
+          close(cntfos)
+
+       end do ! ipw
+       end do ! ipz
+       end do ! ipv
+       end do ! ipm
+       end do ! ips
+
+    end do ! loop
+
+    ! finalize
+    call intp5d%finalize
+    call finalize_cache
+
+    ! dealocate array
+    deallocate(nff)
+
+    return
+  end SUBROUTINE chgres_cnt_fortran
+
+!-------------------------------------------------------------------------------
+!
+!    change the resolution and process division number for cnt
+!    and write into netCDF file
+!                                                   (FUJITSU LTD, November 2021)
+!
+!-------------------------------------------------------------------------------
+  SUBROUTINE chgres_cnt_netcdf( stpn, nnx, ngy, ngz, ngv, ngm, &
+       nnpw, nnpz, nnpv, nnpm, nnps, outdir )
+    integer, optional, intent(in) :: stpn, nnx, ngy, ngz, ngv, ngm, &
+         nnpw, nnpz, nnpv, nnpm, nnps
+    character(len=*), optional, intent(in) :: outdir
+
+    integer :: n_nx, n_gy, n_gz, n_gv, n_gm, n_npw, n_npz, n_npv, n_npm, n_nps
+    integer :: n_ny, n_nz, n_nv, n_nm
+    real(kind=DP), dimension(:), allocatable :: cxl, cyl, czl, cvl, cml
+    integer :: stpnum, ips, ipm, ipv, ipz, ipw, loop
+    integer :: igx0, igy0, igz0, igv0, igm0, igx1, igy1, igz1, igv1, igm1
+    integer :: igx, igy, igz, igv, igm, oiz, oiv(2), oim(2)
+    real(kind=DP) :: time, z0, v0, m0, z1, v1, m1, n_dm, n_dv, n_dz
+    real(kind=DP) :: xx, yy, zz, vv, mm
+    complex(kind=DP) :: f
+    ! buffer for write to file
+    complex(kind=DP), dimension(:,:,:,:,:), allocatable :: nff
+    ! buffer for rb_cnt_ivimisloop (v=2, m=2)
+    complex(kind=DP), target :: &
+         off(2*nx +1, global_ny +1, 2*global_nz, 2, 2)
+    !     off(-nx:nx, 0:global_ny, -global_nz:global_nz-1, 2, 2)
+    complex(kind=DP) :: woff(2*nx +1, global_ny +1, 2*global_nz)
+    !complex(kind=DP) :: woff(-nx:nx, 0:global_ny, -global_nz:global_nz-1)
+    character(len=*), parameter :: default_odir = "./chgres_cnt"
+    character(len=512) :: odir
+    character(len=3) :: cnum
+    integer(kind=4) :: ncid, dimids(1:7), ierr_nf90
+    integer(kind=4) :: varid_kx, varid_ky, varid_zz, varid_vl, varid_mu, &
+         varid_is, varid_tt, varid_recnt, varid_imcnt
+    integer(kind=4) :: start_time(1), count_time(1), start_cnt(7)
+    integer(kind=4), target :: count_cnt0(7), count_cnt1(7)
+    integer(kind=4), dimension(:), pointer :: count_cnt
+    ! 5d complex interpolator
+    type(interp_5d) :: intp5d
+
+    ! check stpnum
+    stpnum = merge(stpn, enum, present(stpn))
+    if (stpnum < snum .or. stpnum > enum) then
+       write(*,*) "chgres_cnt_netcdf: invalid stpnum specified(out of range)"
+       stop
+    end if
+
+    ! check new resolution and process division number
+    n_nx = merge(nnx, nx, present(nnx))
+    n_gy = merge(ngy, global_ny, present(ngy))
+    n_gz = merge(ngz, global_nz, present(ngz))
+    n_gv = merge(ngv, global_nv, present(ngv))
+    n_gm = merge(ngm, global_nm, present(ngm))
+    n_npw = merge(nnpw, nprocw, present(nnpw))
+    n_npz = merge(nnpz, nprocz, present(nnpz))
+    n_npv = merge(nnpv, nprocv, present(nnpv))
+    n_npm = merge(nnpm, nprocm, present(nnpm))
+    n_nps = merge(nnps, nprocs, present(nnps))
+    call check_params(n_nx,n_gy,n_gz,n_gv,n_gm, n_npw,n_npz,n_npv,n_npm,n_nps)
+    n_ny = n_gy / n_npw
+    n_nz = n_gz / n_npz
+    n_nv = n_gv / n_npv
+    n_nm = (n_gm + 1) / n_npm - 1
+
+!<-S.Maeyama(13 March 2022)
+    !! prepare directory for netCDF file
+    !if ( present(outdir) ) then
+    !   odir = outdir
+    !else
+    !   odir = default_odir
+    !end if
+    !call renew_dir( odir )
+!% At present, renewing output directory cause segmentation falut 
+!% in Plasma simulator. So, output directory is fixed to "./data"
+    odir = "./data"
+!>
+
+    ! allocate work for new cnt
+    !allocate( nff(-n_nx:n_nx, 0:n_ny, -n_nz:n_nz-1, 1:2*n_nv, 0:n_nm) )
+    allocate( nff(2*n_nx+1, n_ny+1, 2*n_nz, 2*n_nv, n_nm+1) )
+
+    ! new delta (z, v, m)
+    n_dz = lz / real(ngz, kind=DP)
+    n_dv = 2._DP * vmax / real(2 * n_nv * n_npv -1, kind=DP)
+    n_dm = mmax / real(n_npm * (n_nm+1) -1, kind=DP)
+
+    ! setup new coordinates list
+    allocate( cxl(2*n_nx+1) )
+    do igx = -n_nx, n_nx
+       cxl(igx + n_nx + 1) = kxmin * real(igx, kind=DP)
+    end do
+    allocate( cyl(n_gy+1) )
+    do igy = 0, n_gy
+       cyl(igy + 1) = kymin * real(igy, kind=DP)
+    end do
+    allocate( czl(2*n_gz) )
+    do igz = -n_gz, n_gz - 1
+       czl(igz + n_gz + 1) = n_dz * real(igz, kind=DP)
+    end do
+    allocate( cvl(2*n_gv) )
+    do igv = 1, 2*n_gv
+       cvl(igv) = -vmax + n_dv * real(igv-1, kind=DP)
+    end do
+    allocate( cml(n_gm+1) )
+    do igm = 0, n_gm
+       cml(igm + 1) = 0.5 * (n_dm * real(igm, kind=DP))**2
+    end do
+
+    ! setup interpolator with original mesh
+    call intp5d%initialize(nx*2+1, global_ny+1, global_nz*2, 2, 2)
+    do oiz = 0, 2*global_nz-1
+       intp5d%z(oiz+1) = -lz + dz*oiz
+    end do
+
+    ! open netCDF file
+    write(cnum, fmt="(i3.3)" ) stpnum
+    ierr_nf90 = nf90_create(path=trim(odir)//"/gkvp.cnt."//cnum//".nc", &
+         cmode=NF90_NETCDF4, ncid=ncid)      
+    call check_nf90err(ierr_nf90, "nf90_create")
+
+    ! define dimensions in file
+    ierr_nf90 = nf90_def_dim(ncid=ncid, name="kx", &
+         len=int(2*n_nx+1, kind=4), dimid=dimids(1))
+    ierr_nf90 = nf90_def_dim(ncid=ncid, name="ky", &
+         len=int(n_gy+1, kind=4), dimid=dimids(2))
+    ierr_nf90 = nf90_def_dim(ncid=ncid, name="zz", &
+         len=int(2*n_gz, kind=4), dimid=dimids(3))
+    ierr_nf90 = nf90_def_dim(ncid=ncid, name="vl", &
+         len=int(2*n_gv, kind=4), dimid=dimids(4))
+    ierr_nf90 = nf90_def_dim(ncid=ncid, name="mu", &
+         len=int(n_gm+1, kind=4), dimid=dimids(5))
+    ierr_nf90 = nf90_def_dim(ncid=ncid, name="is", &
+         len=int(n_nps, kind=4),  dimid=dimids(6))
+    ierr_nf90 = nf90_def_dim(ncid=ncid, name="t",  &
+         len=NF90_UNLIMITED, dimid=dimids(7))
+    call check_nf90err(ierr_nf90, "nf90_def_dim")
+
+    ! define variables in file
+    ierr_nf90 = nf90_def_var(ncid=ncid, name="kx", xtype=NF90_DOUBLE, &
+         dimids=dimids(1), varid=varid_kx)
+    ierr_nf90 = nf90_def_var(ncid=ncid, name="ky", xtype=NF90_DOUBLE, &
+         dimids=dimids(2), varid=varid_ky)
+    ierr_nf90 = nf90_def_var(ncid=ncid, name="zz", xtype=NF90_DOUBLE, &
+         dimids=dimids(3), varid=varid_zz)
+    ierr_nf90 = nf90_def_var(ncid=ncid, name="vl", xtype=NF90_DOUBLE, &
+         dimids=dimids(4), varid=varid_vl)
+    ierr_nf90 = nf90_def_var(ncid=ncid, name="mu", xtype=NF90_DOUBLE, &
+         dimids=dimids(5), varid=varid_mu)
+    ierr_nf90 = nf90_def_var(ncid=ncid, name="is", xtype=NF90_INT, &
+         dimids=dimids(6), varid=varid_is)
+    ierr_nf90 = nf90_def_var(ncid=ncid, name="t",  xtype=NF90_DOUBLE, &
+         dimids=dimids(7), varid=varid_tt)
+    ierr_nf90 = nf90_def_var(ncid=ncid, name="recnt", xtype=NF90_DOUBLE, &
+         dimids=dimids(1:7), varid=varid_recnt)
+    ierr_nf90 = nf90_def_var(ncid=ncid, name="imcnt", xtype=NF90_DOUBLE, &
+         dimids=dimids(1:7), varid=varid_imcnt)
+    call check_nf90err(ierr_nf90, "nf90_def_var")
+
+    ! end of definition of file
+    ierr_nf90 = nf90_enddef(ncid=ncid)
+    call check_nf90err(ierr_nf90, "nf90_enddef")
+
+    ! write variables: static coordinates
+    ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_kx, values=cxl)
+    ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_ky, values=cyl)
+    ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_zz, values=czl)
+    ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_vl, values=cvl)
+    ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_mu, values=cml)
+    ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_is, &
+         values=(/ (ips, ips=0,n_nps-1) /))
+    call check_nf90err(ierr_nf90, "nf90_putvar")
+
+    count_time(:) = 1
+    count_cnt0(:) = int((/ 2*n_nx+1, n_ny+1, 2*n_nz, 2*n_nv, n_nm+1, 1, 1 /))
+    count_cnt1 = count_cnt0
+    count_cnt1(2) = n_gy + 1 - (n_ny+1)*(n_npw-1)
+
+    ! main loop (in new process division)
+    do loop = loop_cnt_sta(stpnum), loop_cnt_end(stpnum)
+       ! get time
+       call rb_cnt_gettime(loop, time)
+       start_time(:) = 1 + loop - loop_cnt_sta(stpnum)
+       ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_tt, values=(/time/), &
+            start=start_time, count=count_time)
+       call check_nf90err(ierr_nf90, "nf90_putvar")
+       
+       do ips = 0, n_nps-1
+          
+       ! initialize buffer cache
+       call initialize_cache(ips, loop, 2*n_nv *3)
+
+       do ipm = 0, n_npm-1
+       do ipv = 0, n_npv-1
+       do ipz = 0, n_npz-1
+       do ipw = 0, n_npw-1
+          nff(:, :, :, :, :) = (0.0, 0.0)
+          start_cnt(:) = int((/ 1, ipw*(n_ny+1)+1, ipz*(2*n_nz)+1, &
+               ipv*(2*n_nv)+1, ipm*(n_nm+1)+1, ips+1, &
+               loop-loop_cnt_sta(stpnum)+1 /))
+          if ( ipw == n_npw-1 ) then
+             count_cnt => count_cnt1
+          else
+             count_cnt => count_cnt0
+          end if
+
+          ! case of extends 's'
+          if ( ips >= nprocs ) then
+             ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_recnt, &
+                  values=dble(nff), start=start_cnt, count=count_cnt)
+             ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_imcnt, &
+                  values=aimag(nff), start=start_cnt, count=count_cnt)
+             call check_nf90err(ierr_nf90, "nf90_putvar")
+             cycle
+          end if
+
+          ! new index range in global
+          igx0 = -n_nx; igx1 = n_nx
+          igy0 = ipw*(n_ny+1); igy1 = min(igy0+n_ny, n_gy)
+          igz0 = -n_gz + ipz*2*n_nz; igz1 = igz0 + 2*n_nz -1
+          igv0 = 1 + ipv*2*n_nv; igv1 = igv0 + 2*n_nv -1
+          igm0 = ipm*(n_nm+1); igm1 = igm0 + n_nm
+
+          ! new coordinate range (z, v, m)
+          z0 = igz0 * n_dz; z1 = igz1 * n_dz
+          v0 = -vmax + (igv0-1)*n_dv; v1 = -vmax + (igv1-1)*n_dv
+          m0 = igm0 * n_dm; m1 = igm1 * n_dm
+
+          ! in process loop
+          do igm = igm0, igm1
+             mm = m0 + (igm-igm0)*n_dm
+             do igv = igv0, igv1
+                vv = v0 + (igv-igv0)*n_dv
+                
+                ! get original indices around (v, m)
+                call get_org_ivim(vv, mm, oiv, oim)
+
+                ! get off(:, :, :, 1:2, 1:2) around (v, m)
+                ! (v, m) = (1, 1)
+                call get_blk(oiv(1), oim(1), woff)
+                off(:, :, :, 1, 1) = woff
+                ! (v, m) = (2, 1)
+                call get_blk(oiv(2), oim(1), woff)
+                off(:, :, :, 2, 1) = woff
+                ! (v, m) = (1, 2)
+                call get_blk(oiv(1), oim(2), woff)
+                off(:, :, :, 1, 2) = woff
+                ! (v, m) = (2, 2)
+                call get_blk(oiv(2), oim(2), woff)
+                off(:, :, :, 2, 2) = woff
+
+                ! setup interpolator
+                intp5d%v(1) = -vmax + dv * (oiv(1)-1)
+                intp5d%v(2) = -vmax + dv * (oiv(2)-1)
+                intp5d%m(1) = dm * oim(1)
+                intp5d%m(2) = dm * oim(2)
+                intp5d%f => off
+
+                ! interplation loop
+                do igz = igz0, igz1
+                   zz = z0 + (igz-igz0)*n_dz
+                   do igy = igy0, igy1
+                      ! case of extends 'y'
+!<-S.Maeyama(13 March 2022)
+                      !if ( igy > global_nz ) then
+!% Fix a bug
+                      if ( igy > global_ny ) then
+!>
+                         do igx = igx0, igx1
+                            nff(igx-igx0+1, igy-igy0+1, igz-igz0+1, &
+                                 igv-igv0+1, igm-igm0+1) = (0.0, 0.0)
+                         end do
+                         cycle
+                      end if
+                      yy = real(igy)
+                      do igx = igx0, igx1
+                         ! case of extends 'x'
+                         if ( igx < -nx .or. igx > nx ) then
+                            f = (0.0, 0.0)
+                         else
+                            xx = real(igx)
+                            call intp5d%interpolate(xx, yy, zz, vv, mm, f)
+                         end if
+                         nff(igx-igx0+1, igy-igy0+1, igz-igz0+1, &
+                              igv-igv0+1, igm-igm0+1) = f
+                      end do
+                   end do
+                end do
+
+             end do ! igv
+          end do ! igm
+
+          ! set values onto netCDF
+          ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_recnt, &
+               values=dble(nff(:,1:count_cnt(2),:,:,:)), &
+               start=start_cnt, count=count_cnt)
+          ierr_nf90 = nf90_put_var(ncid=ncid, varid=varid_imcnt, &
+               values=aimag(nff(:,1:count_cnt(2),:,:,:)), &
+               start=start_cnt, count=count_cnt)
+          call check_nf90err(ierr_nf90, "nf90_putvar")
+
+       end do ! ipw
+       end do ! ipz
+       end do ! ipv
+       end do ! ipm
+       end do ! ips
+
+    end do ! loop
+
+    ! close netCDF file
+    ierr_nf90 = nf90_close(ncid)
+    call check_nf90err(ierr_nf90, "nf90_close")
+    
+    ! finalize
+    call intp5d%finalize()
+    call finalize_cache
+
+    ! dealocate arrays
+    deallocate(nff)
+    deallocate(cxl, cyl, czl, cvl, cml)
+
+    return
+  end SUBROUTINE chgres_cnt_netcdf
+  
+end MODULE diag_chgres_cnt

--- a/src/diag_chgres_util.f90
+++ b/src/diag_chgres_util.f90
@@ -1,0 +1,522 @@
+!-------------------------------------------------------------------------------
+!
+!    diag_interp: interpolation complex array
+!                                                   (FUJITSU LTD, November 2021)
+!
+!-------------------------------------------------------------------------------
+MODULE diag_interp
+  use diag_header, only: DP
+  implicit none
+  private
+
+  real(kind=DP), parameter :: zero = 0.0_DP, one = 1.0_DP
+
+  !----------------------------------------------------------------------------
+  ! interpolator class for complex 5d(x, y, z, v, m) data
+  !----------------------------------------------------------------------------
+  type, public :: interp_5d
+     complex(kind=DP), dimension(:,:,:,:,:), pointer :: f
+     real(kind=DP), dimension(:), allocatable :: x, y, z, v, m
+     integer :: ilox = 1, iloy = 1, iloz = 1, ilov = 1, ilom = 1
+     logical :: initialized = .false.
+   contains
+     procedure, public :: initialize => initialize_interp_5d
+     procedure, public :: interpolate => interpolate_interp_5d
+     procedure, public :: finalize => finalize_interp_5d
+  end type interp_5d
+
+
+CONTAINS
+
+  !-------------------------------------------------------------------------
+  ! returns the indices in `xl` that bound `x`, to use for interpolation.
+  ! and set mflag as blow
+  !   if            x < xl(1)   then ileft=1,   iright=2,    mflag=-1
+  !   if   xl(i) <= x < xl(i+1) then ileft=i,   iright=i+1,  mflag=0
+  !   if   xl(n) == x           then ileft=n-1, iright=n,    mflag=0
+  !   if    xl(n) < x           then ileft=n-1, iright=n,    mflag=1
+  !-------------------------------------------------------------------------
+  pure subroutine dintrv(xl, x, ilo, ileft, iright, mflag)
+    implicit none
+    real(kind=DP), dimension(:), intent(in) :: xl
+    real(kind=DP), intent(in) :: x
+    integer, intent(inout) :: ilo
+    integer, intent(out) :: ileft, iright, mflag
+    integer :: ihi, istep, imid, n
+
+    n = size(xl)
+    if ( n == 1 ) then
+       return
+    end if
+
+    ihi = ilo + 1
+    if ( ihi >= n ) then
+       if ( x >= xl(n) ) then
+          if ( x == xl(n) ) then
+             mflag = 0
+          else
+             mflag = 1
+          end if
+          ileft = n - 1
+          iright = n
+          return
+       end if
+       if ( n <= 1 ) then
+          mflag = -1
+          ileft = 1
+          iright = 2
+          return
+       end if
+       ilo = n - 1
+       ihi = n
+    endif
+
+    if ( x >= xl(ihi) ) then
+       istep = 1
+       do
+          ilo = ihi
+          ihi = ilo + istep
+          if ( ihi >= n ) then
+             if ( x >= xl(n) ) then
+                if ( x == xl(n) ) then
+                   mflag = 0
+                else
+                   mflag = 1
+                end if
+                ileft = n-1
+                iright = n
+                return
+             end if
+             ihi = n
+          else if ( x >= xl(ihi) ) then
+             istep = istep*2
+             cycle
+          endif
+          exit
+       end do
+    else
+       if ( x >= xl(ilo) ) then
+          mflag = 0
+          ileft = ilo
+          iright = ilo + 1
+          return
+       end if
+       istep = 1
+       do
+          ihi = ilo
+          ilo = ihi - istep
+          if ( ilo <= 1 ) then
+             ilo = 1
+             if ( x < xl(1) ) then
+                mflag = -1
+                ileft = 1
+                iright = 2
+                return
+             end if
+          elseif ( x < xl(ilo) ) then
+             istep = istep*2
+             cycle
+          endif
+          exit
+       end do
+    endif
+
+    do
+       imid = (ilo + ihi) / 2
+       if ( imid == ilo ) then
+          mflag = 0
+          ileft = ilo
+          iright = ilo + 1
+          return
+       end if
+       if ( x < xl(imid) ) then
+          ihi = imid
+       else
+          ilo = imid
+       endif
+    end do
+  end subroutine dintrv
+  
+  !-------------------------------------------------------------------------
+  ! constructor for interp_5d class
+  !-------------------------------------------------------------------------
+  subroutine initialize_interp_5d(me_, nx, ny, nz, nv, nm)
+    implicit none
+    class(interp_5d), intent(inout) :: me_
+    integer, intent(in) :: nx, ny, nz, nv, nm
+    integer :: i
+
+    call me_%finalize()
+
+!<-S.Maeyama(13 March 2022)
+    !if ( nx < 2 .or. ny < 2 .or. nz < 2 .or. nv < 2 .or. nm < 2 ) then
+!% Extention for nx=0 in old file
+    if ( nx < 1 .or. ny < 2 .or. nz < 2 .or. nv < 2 .or. nm < 2 ) then
+!>
+       return
+    end if
+
+    allocate(me_%x(nx))
+    allocate(me_%y(ny))
+    allocate(me_%z(nz))
+    allocate(me_%v(nv))
+    allocate(me_%m(nm))
+
+    do i = 1, nx
+       !me_%x(i) = real(i-1)
+       me_%x(i) = real(-(nx-1)/2 + (i-1))
+    end do
+    do i = 1, ny
+       me_%y(i) = real(i-1)
+    end do
+    do i = 1, nz
+       me_%z(i) = real(i-1)
+    end do
+    do i = 1, nv
+       me_%v(i) = real(i-1)
+    end do
+    do i = 1, nm
+       me_%m(i) = real(i-1)
+    end do
+
+    me_%initialized = .true.
+  end subroutine initialize_interp_5d
+
+  !-------------------------------------------------------------------------
+  ! interpolation complex 5d data
+  !-------------------------------------------------------------------------
+  subroutine interpolate_interp_5d(me_, x, y, z, v, m, f, istat)
+    implicit none
+    class(interp_5d), intent(inout) :: me_
+    real(kind=DP), intent(in) :: x, y, z, v, m
+    complex(kind=DP), intent(out) :: f
+    integer, intent(out), optional :: istat
+
+    integer, dimension(2) :: ix, iy, iz, iv, im
+    real(kind=DP) :: p1, p2, p3, p4, p5
+    real(kind=DP) :: q1, q2, q3, q4, q5
+    integer :: mflag
+    complex(kind=DP) :: &
+         fx1111, fx2111, fx1211, fx2211, fx1121, fx2121, fx1221, fx2221, &
+         fxy111, fxy211, fxy121, fxy221, fxyz11, fxyz21, fxyzv1, fx1112, &
+         fx2112, fx1212, fx2212, fx1122, fx2122, fx1222, fx2222, fxy112, &
+         fxy212, fxy122, fxy222, fxyz12, fxyz22, fxyzv2
+    
+    if ( me_%initialized .eqv. .false. .or. .not. associated(me_%f)) then
+       f = zero
+       if ( present(istat) ) istat = -1
+       return
+    end if
+    
+!<-S.Maeyama(13 March 2022)
+    !call dintrv(me_%x, x, me_%ilox, ix(1), ix(2), mflag)
+!% Extention for nx=0 in old file
+    if (size(me_%x)==1) then
+      if (me_%x(1)==x) then
+        ix(1) = -9999
+        ix(2) = 1
+      else
+        write(*,*) "Wrong call for interp in x: old nx=",size(me_%x),", ix=", me_%x(1), x
+        stop
+      end if
+    else
+      call dintrv(me_%x, x, me_%ilox, ix(1), ix(2), mflag)
+    end if
+!>
+    call dintrv(me_%y, y, me_%iloy, iy(1), iy(2), mflag)
+    call dintrv(me_%z, z, me_%iloz, iz(1), iz(2), mflag)
+    call dintrv(me_%v, v, me_%ilov, iv(1), iv(2), mflag)
+    call dintrv(me_%m, m, me_%ilom, im(1), im(2), mflag)
+
+!<-S.Maeyama(13 March 2022)
+    !q1 = (x - me_%x(ix(1))) / (me_%x(ix(2)) - me_%x(ix(1)))
+!% Extention for nx=0 in old file
+    if (size(me_%x)==1 .and. me_%x(1)==x) then
+      q1 = one
+    else
+      q1 = (x - me_%x(ix(1))) / (me_%x(ix(2)) - me_%x(ix(1)))
+    end if
+!>
+    q2 = (y - me_%y(iy(1))) / (me_%y(iy(2)) - me_%y(iy(1)))
+    q3 = (z - me_%z(iz(1))) / (me_%z(iz(2)) - me_%z(iz(1)))
+    q4 = (v - me_%v(iv(1))) / (me_%v(iv(2)) - me_%v(iv(1)))
+    q5 = (m - me_%m(im(1))) / (me_%m(im(2)) - me_%m(im(1)))
+    p1 = one - q1
+    p2 = one - q2
+    p3 = one - q3
+    p4 = one - q4
+    p5 = one - q5
+
+!<-S.Maeyama(13 March 2022)
+    !fx1111 = p1*me_%f(ix(1),iy(1),iz(1),iv(1),im(1)) &
+    !     +   q1*me_%f(ix(2),iy(1),iz(1),iv(1),im(1))
+    !fx2111 = p1*me_%f(ix(1),iy(2),iz(1),iv(1),im(1)) &
+    !     +   q1*me_%f(ix(2),iy(2),iz(1),iv(1),im(1))
+    !fx1211 = p1*me_%f(ix(1),iy(1),iz(2),iv(1),im(1)) &
+    !     +   q1*me_%f(ix(2),iy(1),iz(2),iv(1),im(1))
+    !fx2211 = p1*me_%f(ix(1),iy(2),iz(2),iv(1),im(1)) &
+    !     +   q1*me_%f(ix(2),iy(2),iz(2),iv(1),im(1))
+    !fx1121 = p1*me_%f(ix(1),iy(1),iz(1),iv(2),im(1)) &
+    !     +   q1*me_%f(ix(2),iy(1),iz(1),iv(2),im(1))
+    !fx2121 = p1*me_%f(ix(1),iy(2),iz(1),iv(2),im(1)) &
+    !     +   q1*me_%f(ix(2),iy(2),iz(1),iv(2),im(1))
+    !fx1221 = p1*me_%f(ix(1),iy(1),iz(2),iv(2),im(1)) &
+    !     +   q1*me_%f(ix(2),iy(1),iz(2),iv(2),im(1))
+    !fx2221 = p1*me_%f(ix(1),iy(2),iz(2),iv(2),im(1)) &
+    !     +   q1*me_%f(ix(2),iy(2),iz(2),iv(2),im(1))
+    !fx1112 = p1*me_%f(ix(1),iy(1),iz(1),iv(1),im(2)) &
+    !     +   q1*me_%f(ix(2),iy(1),iz(1),iv(1),im(2))
+    !fx2112 = p1*me_%f(ix(1),iy(2),iz(1),iv(1),im(2)) &
+    !     +   q1*me_%f(ix(2),iy(2),iz(1),iv(1),im(2))
+    !fx1212 = p1*me_%f(ix(1),iy(1),iz(2),iv(1),im(2)) &
+    !     +   q1*me_%f(ix(2),iy(1),iz(2),iv(1),im(2))
+    !fx2212 = p1*me_%f(ix(1),iy(2),iz(2),iv(1),im(2)) &
+    !     +   q1*me_%f(ix(2),iy(2),iz(2),iv(1),im(2))
+    !fx1122 = p1*me_%f(ix(1),iy(1),iz(1),iv(2),im(2)) &
+    !     +   q1*me_%f(ix(2),iy(1),iz(1),iv(2),im(2))
+    !fx2122 = p1*me_%f(ix(1),iy(2),iz(1),iv(2),im(2)) &
+    !     +   q1*me_%f(ix(2),iy(2),iz(1),iv(2),im(2))
+    !fx1222 = p1*me_%f(ix(1),iy(1),iz(2),iv(2),im(2)) &
+    !     +   q1*me_%f(ix(2),iy(1),iz(2),iv(2),im(2))
+    !fx2222 = p1*me_%f(ix(1),iy(2),iz(2),iv(2),im(2)) &
+    !     +   q1*me_%f(ix(2),iy(2),iz(2),iv(2),im(2))
+!% Extention for nx=0 in old file
+    if (size(me_%x)==1 .and. me_%x(1)==x) then
+      fx1111 = q1*me_%f(ix(2),iy(1),iz(1),iv(1),im(1))
+      fx2111 = q1*me_%f(ix(2),iy(2),iz(1),iv(1),im(1))
+      fx1211 = q1*me_%f(ix(2),iy(1),iz(2),iv(1),im(1))
+      fx2211 = q1*me_%f(ix(2),iy(2),iz(2),iv(1),im(1))
+      fx1121 = q1*me_%f(ix(2),iy(1),iz(1),iv(2),im(1))
+      fx2121 = q1*me_%f(ix(2),iy(2),iz(1),iv(2),im(1))
+      fx1221 = q1*me_%f(ix(2),iy(1),iz(2),iv(2),im(1))
+      fx2221 = q1*me_%f(ix(2),iy(2),iz(2),iv(2),im(1))
+      fx1112 = q1*me_%f(ix(2),iy(1),iz(1),iv(1),im(2))
+      fx2112 = q1*me_%f(ix(2),iy(2),iz(1),iv(1),im(2))
+      fx1212 = q1*me_%f(ix(2),iy(1),iz(2),iv(1),im(2))
+      fx2212 = q1*me_%f(ix(2),iy(2),iz(2),iv(1),im(2))
+      fx1122 = q1*me_%f(ix(2),iy(1),iz(1),iv(2),im(2))
+      fx2122 = q1*me_%f(ix(2),iy(2),iz(1),iv(2),im(2))
+      fx1222 = q1*me_%f(ix(2),iy(1),iz(2),iv(2),im(2))
+      fx2222 = q1*me_%f(ix(2),iy(2),iz(2),iv(2),im(2))
+    else
+      fx1111 = p1*me_%f(ix(1),iy(1),iz(1),iv(1),im(1)) &
+           +   q1*me_%f(ix(2),iy(1),iz(1),iv(1),im(1))
+      fx2111 = p1*me_%f(ix(1),iy(2),iz(1),iv(1),im(1)) &
+           +   q1*me_%f(ix(2),iy(2),iz(1),iv(1),im(1))
+      fx1211 = p1*me_%f(ix(1),iy(1),iz(2),iv(1),im(1)) &
+           +   q1*me_%f(ix(2),iy(1),iz(2),iv(1),im(1))
+      fx2211 = p1*me_%f(ix(1),iy(2),iz(2),iv(1),im(1)) &
+           +   q1*me_%f(ix(2),iy(2),iz(2),iv(1),im(1))
+      fx1121 = p1*me_%f(ix(1),iy(1),iz(1),iv(2),im(1)) &
+           +   q1*me_%f(ix(2),iy(1),iz(1),iv(2),im(1))
+      fx2121 = p1*me_%f(ix(1),iy(2),iz(1),iv(2),im(1)) &
+           +   q1*me_%f(ix(2),iy(2),iz(1),iv(2),im(1))
+      fx1221 = p1*me_%f(ix(1),iy(1),iz(2),iv(2),im(1)) &
+           +   q1*me_%f(ix(2),iy(1),iz(2),iv(2),im(1))
+      fx2221 = p1*me_%f(ix(1),iy(2),iz(2),iv(2),im(1)) &
+           +   q1*me_%f(ix(2),iy(2),iz(2),iv(2),im(1))
+      fx1112 = p1*me_%f(ix(1),iy(1),iz(1),iv(1),im(2)) &
+           +   q1*me_%f(ix(2),iy(1),iz(1),iv(1),im(2))
+      fx2112 = p1*me_%f(ix(1),iy(2),iz(1),iv(1),im(2)) &
+           +   q1*me_%f(ix(2),iy(2),iz(1),iv(1),im(2))
+      fx1212 = p1*me_%f(ix(1),iy(1),iz(2),iv(1),im(2)) &
+           +   q1*me_%f(ix(2),iy(1),iz(2),iv(1),im(2))
+      fx2212 = p1*me_%f(ix(1),iy(2),iz(2),iv(1),im(2)) &
+           +   q1*me_%f(ix(2),iy(2),iz(2),iv(1),im(2))
+      fx1122 = p1*me_%f(ix(1),iy(1),iz(1),iv(2),im(2)) &
+           +   q1*me_%f(ix(2),iy(1),iz(1),iv(2),im(2))
+      fx2122 = p1*me_%f(ix(1),iy(2),iz(1),iv(2),im(2)) &
+           +   q1*me_%f(ix(2),iy(2),iz(1),iv(2),im(2))
+      fx1222 = p1*me_%f(ix(1),iy(1),iz(2),iv(2),im(2)) &
+           +   q1*me_%f(ix(2),iy(1),iz(2),iv(2),im(2))
+      fx2222 = p1*me_%f(ix(1),iy(2),iz(2),iv(2),im(2)) &
+           +   q1*me_%f(ix(2),iy(2),iz(2),iv(2),im(2))
+    end if
+!>
+
+    fxy111 = p2*fx1111 + q2*fx2111
+    fxy211 = p2*fx1211 + q2*fx2211
+    fxy121 = p2*fx1121 + q2*fx2121
+    fxy221 = p2*fx1221 + q2*fx2221
+    fxy112 = p2*fx1112 + q2*fx2112
+    fxy212 = p2*fx1212 + q2*fx2212
+    fxy122 = p2*fx1122 + q2*fx2122
+    fxy222 = p2*fx1222 + q2*fx2222
+
+    fxyz11 = p3*fxy111 + q3*fxy211
+    fxyz21 = p3*fxy121 + q3*fxy221
+    fxyz12 = p3*fxy112 + q3*fxy212
+    fxyz22 = p3*fxy122 + q3*fxy222
+
+    fxyzv1 = p4*fxyz11 + q4*fxyz21
+    fxyzv2 = p4*fxyz12 + q4*fxyz22
+
+    f = p5*fxyzv1 + q5*fxyzv2
+    
+    if ( present(istat) ) istat = 0
+    return
+  end subroutine interpolate_interp_5d
+
+  !-------------------------------------------------------------------------
+  ! destructor for interp_5d class
+  !-------------------------------------------------------------------------
+  subroutine finalize_interp_5d(me_)
+    implicit none
+    class(interp_5d), intent(inout) :: me_
+
+    if ( associated(me_%f) ) nullify(me_%f)
+    if ( allocated(me_%x) ) deallocate(me_%x)
+    if ( allocated(me_%y) ) deallocate(me_%y)
+    if ( allocated(me_%z) ) deallocate(me_%z)
+    if ( allocated(me_%v) ) deallocate(me_%v)
+    if ( allocated(me_%m) ) deallocate(me_%m)
+    me_%ilox = 1
+    me_%iloy = 1
+    me_%iloz = 1
+    me_%ilov = 1
+    me_%ilom = 1
+    me_%initialized = .false.
+  end subroutine finalize_interp_5d
+
+end MODULE diag_interp
+
+
+!-------------------------------------------------------------------------------
+!
+!    diag_cache_cnt: cache for cnt(x,y,z) array
+!                                                   (FUJITSU LTD, November 2021)
+!
+!-------------------------------------------------------------------------------
+MODULE diag_cache_cnt
+  use diag_header
+  use diag_rb, only : rb_cnt_ivimisloop
+  implicit none
+
+  !----------------------------------------------------------------------------
+  ! cache buffer class for cnt(x, y, z) block indexed by (v, m)
+  !----------------------------------------------------------------------------
+  type, public :: cntbuff
+     complex :: idx = (-1.0, -1.0) ! (v, m*i)
+     complex(kind=DP) :: pd(2*nx +1, global_ny +1, 2*global_nz)
+     integer :: age = 0
+   contains
+     procedure, public :: set => set_idx_pd
+  end type cntbuff
+
+  public initialize_cache, get_blk, finalize_cache
+  integer :: ips = 0, stp = 0
+  complex :: ei = (0.0, 1.0)
+  integer :: num_blk = 0
+  type(cntbuff), dimension(:), allocatable :: cnt_lst
+
+CONTAINS
+
+  subroutine set_idx_pd(this, v, m, s, t)
+    class(cntbuff), intent(inout) :: this
+    integer, intent(in) :: v, m, s, t
+    this%idx = real(v) + real(m)*ei
+    if ( v < 0 .or. m < 0 ) then
+       this%age = 0
+       return
+    end if
+    call rb_cnt_ivimisloop(v, m, s, t, this%pd)
+    this%age = 1
+    return
+  end subroutine set_idx_pd
+
+  !-------------------------------------------------------------------------
+  ! initialize chache list
+  !-------------------------------------------------------------------------
+  SUBROUTINE initialize_cache( is, istp, nb, istatus )
+    integer, intent(in) :: is, istp
+    integer, optional, intent(in) :: nb
+    integer, optional, intent(out) :: istatus
+
+    call finalize_cache
+    
+    ! adjust number of blks
+    if ( present(nb) ) then
+       num_blk = nb
+    else
+       num_blk = global_nv *2
+    end if
+    if ( num_blk < 2 ) num_blk = 2
+
+    ! store ips and stp
+    ips = is
+    stp = istp
+
+    ! allocate buffer
+    if ( present(istatus) ) then
+       allocate( cnt_lst(num_blk), stat=istatus )
+    else
+       allocate( cnt_lst(num_blk) )
+    end if
+    return
+  end SUBROUTINE initialize_cache
+
+  !-------------------------------------------------------------------------
+  ! get block from chache list
+  !-------------------------------------------------------------------------
+  SUBROUTINE get_blk( v, m, p )
+    integer, intent(in) :: v, m
+    complex(kind=DP), dimension(:,:,:), intent(out) :: p
+    complex :: idx
+    integer :: i, j, vacancy
+    logical :: found
+
+    if ( v < 1 .or. v > 2*global_nv .or. m < 0 .or. m > global_nm ) then
+       p = (0.0, 0.0)
+       return
+    end if
+
+    idx = real(v) + real(m)*ei
+    vacancy = 0; found = .false.
+    do i = 1, num_blk
+       if ( cnt_lst(i)%idx == idx ) then ! cache hit
+          p = cnt_lst(i)%pd
+          cnt_lst(i)%age = 1
+          found = .true.
+       else if ( cnt_lst(i)%age > 0 ) then
+          cnt_lst(i)%age = cnt_lst(i)%age + 1
+       else if ( vacancy == 0 ) then
+          vacancy = i
+       end if
+    end do
+
+    ! found in cache
+    if ( found .eqv. .true. ) then
+       return
+    end if
+
+    ! not found in cache
+    if ( vacancy > 0 ) then ! vacancy exists
+       call cnt_lst(vacancy)%set(v, m, ips, stp)
+       p = cnt_lst(vacancy)%pd
+       return
+    end if
+
+    ! select the oldest one
+    vacancy = 1
+    do i = 2, num_blk
+       if ( cnt_lst(vacancy)%age < cnt_lst(i)%age ) then
+          vacancy = i
+       end if
+    end do
+    call cnt_lst(vacancy)%set(v, m, ips, stp)
+    p = cnt_lst(vacancy)%pd
+    return
+  end SUBROUTINE get_blk
+
+  !-------------------------------------------------------------------------
+  ! finalize chache list
+  !-------------------------------------------------------------------------
+  SUBROUTINE finalize_cache
+    integer :: i
+    if ( .not. allocated(cnt_lst) ) return
+    deallocate( cnt_lst )
+    num_blk = 0
+    return
+  end SUBROUTINE finalize_cache
+
+end MODULE diag_cache_cnt

--- a/src/diag_fft.f90
+++ b/src/diag_fft.f90
@@ -217,7 +217,8 @@ SUBROUTINE fft_time2freq_init ( nsample )
 
 !    call dfftw_plan_with_nthreads( 1 )
     call dfftw_plan_dft_1d( plan_time2freq,    &
-                            int(nsample,kind=4),           &
+                            nsample,           &
+                            !int(nsample,kind=4),           &
                             sample, spectrum,  &
                             FFTW_FORWARD,      &
                             FFTW_ESTIMATE )

--- a/src/diag_rb_fortran.f90
+++ b/src/diag_rb_fortran.f90
@@ -2986,7 +2986,7 @@ END SUBROUTINE rb_cnt_ivimisloop
 SUBROUTINE rb_cnt_izivimisloop( giz, giv, gim, is, loop, ff )
 !-------------------------------------------------------------------------------
 !
-!     Get ff at giv, gim, is, loop
+!     Get ff at giz, giv, gim, is, loop
 !                                                   (S. Maeyama, 11 Oct. 2015)
 !
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
To allow changing resolution and MPI decomposition when restarting your run, diag_chgres module (diag_chgres_cnt.f90 and diag_chgres_util.f90, developed by Fujitsu, extended by S. Maeyama) is added.

Example to use (in diag_main.f90):
```
import diag_chgres_cnt, only : chgres_cnt_netcdf, chgres_cnt_fortran
stpn = 1  ! Run number of existing cnt file, of which you want to change resolution
nnx = 48  ! New resolution of nx in gkvp_header.f90
ngy = 19  ! New resolution of global_ny in gkvp_header.f90
ngz = 32  ! New resolution of global_nz in gkvp_header.f90
ngv = 48  ! New resolution of global_nv in gkvp_header.f90
ngm = 47  ! New resolution of global_nm in gkvp_header.f90
nnpw = 2  ! New MPI decomposition of nprocw in gkvp_header.f90
nnpz = 4  ! New MPI decomposition of nprocz in gkvp_header.f90
nnpv = 4  ! New MPI decomposition of nprocv in gkvp_header.f90
nnpm = 4  ! New MPI decomposition of nprocm in gkvp_header.f90
nnps = 3  ! New MPI decomposition of nprocs in gkvp_header.f90
!### For Fortran binary output, cnt/gkvp.******.cnt.***
call chgres_cnt_fortran(stpn=stpn,nnx=nnx, ngy=ngy, ngz=ngz, ngv=ngv, ngm=ngm, &
                        nnpw=nnpw, nnpz=nnpz, nnpv=nnpv, nnpm=nnpm, nnps=nnps)
!### For NetCDF4 output, cnt/gkvp.cnt.***.nc
!call chgres_cnt_netcdf(stpn=stpn,nnx=nnx, ngy=ngy, ngz=ngz, ngv=ngv, ngm=ngm, &
!                       nnpw=nnpw, nnpz=nnpz, nnpv=nnpv, nnpm=nnpm, nnps=nnps)
```

Increments of mode number In kx and ky => zero padding.
Decrease of mode number in kx and ky => truncated.
Resolution change in z,v,m directions => linear interpolations.
Increments of plasma species s => zero padding.
Decrease of plasma species s => truncated.
